### PR TITLE
Changed single code comment coloring

### DIFF
--- a/assets/scss/common/_dark.scss
+++ b/assets/scss/common/_dark.scss
@@ -266,7 +266,8 @@ $navbar-dark-active-color: $link-color-dark;
 }
 
 [data-dark-mode] #form::after,
-[data-dark-mode] #form-search:after {
+[data-dark-mode] #form-search:after,
+[data-dark-mode] body .doks-search::after {
   color: $gray-300;
   border: 1px solid $gray-700;
 }
@@ -310,9 +311,15 @@ $navbar-dark-active-color: $link-color-dark;
   background: $gray-400;
 }
 
-[data-dark-mode] body code:not(.hljs) {
-  background: $body-overlay-dark;
+[data-dark-mode] body code:not(.hljs),
+[data-dark-mode] body .alert-note code:not(.hljs) {
+  background: #4e4e4e;
   color: $body-color-dark;
+}
+
+[data-dark-mode] body .alert-warning code:not(.hljs) {
+  background: $gray-300;
+  color: #664d03;
 }
 
 [data-dark-mode] body pre code:hover {
@@ -534,4 +541,10 @@ $navbar-dark-active-color: $link-color-dark;
     background-color: $body-overlay-dark;
     border-color: $border-dark;
   }
+}
+
+/* Image is in section WHAT IS GAMEFACE? -> Differences to traditional browsers */
+/* In Native documentation */
+[data-dark-mode] figure img[title="Color matrix syntax"] {
+  filter: invert(1);
 }

--- a/assets/scss/components/_alerts.scss
+++ b/assets/scss/components/_alerts.scss
@@ -96,6 +96,11 @@
   border-color: #ffecb5;
 }
 
+body .alert-warning code:not(.hljs),
+body .alert-note code:not(.hljs) {
+  background: $gray-300;
+}
+
 .alert-warning .alert-link {
   color: #523e02;
 }

--- a/assets/scss/components/_code.scss
+++ b/assets/scss/components/_code.scss
@@ -8,7 +8,7 @@ samp {
 }
 
 code {
-  background: $beige;
+  background: $gray-300;
   color: $black;
   padding: 0.25rem 0.5rem;
 }


### PR DESCRIPTION
You can temporarily test here http://192.168.88.40:8080/something4/html/integration/gettingstarted/

* The `[data-dark-mode] body .doks-search::after {` selector was transferred from [Unreal repo's _dark.scss](https://github.com/CoherentLabs/CoherentUI_UE4/blob/develop/CoherentSample/Documentation_Source/assets/scss/common/_dark.scss#L268) in order to remove it from there and use the commont theme's _dark.scss file.
* **UPDATE:** The `[data-dark-mode] figure img[title="Color matrix syntax"]` selector was added from [cohtml repo's _dark.scss](https://github.com/CoherentLabs/cohtml/blob/develop/Documentation_Source/assets/scss/common/_dark.scss) so it can be removed from cohtml repo later.

![image](https://user-images.githubusercontent.com/21058220/225910924-96063755-d2eb-4b88-8e3e-848f1bfd6b84.png)


## UPDATE: alert boxes new coloring:
![image](https://user-images.githubusercontent.com/21058220/225955212-514bbee8-9bfc-452f-aa7f-277d15ad087e.png)


