### PR TITLE
Use sha256

### DIFF
--- a/layouts/partials/footer/script-footer.html
+++ b/layouts/partials/footer/script-footer.html
@@ -63,7 +63,7 @@
 
 {{ if .Site.Params.options.cookieConsent }}
   {{ $cookieConsentPlugin := resources.Get "vanilla-cookieconsent/cookieconsent.js" -}}
-  {{ $cookieConsentInit := resources.Get "js/cookieconsent-init.js" | minify | fingerprint "md5" -}}
+  {{ $cookieConsentInit := resources.Get "js/cookieconsent-init.js" | minify | fingerprint "sha256" -}}
   {{ $slice = $slice | append $cookieConsentPlugin | append $cookieConsentInit -}}
 {{ end -}}
 
@@ -100,18 +100,18 @@
     {{ end -}}
   {{ end -}}
 {{ else -}}
-  {{ $js := $js | minify | fingerprint "md5" -}}
-  {{ $searchUtilities := $searchUtilities | minify | fingerprint "md5" -}}
+  {{ $js := $js | minify | fingerprint "sha256" -}}
+  {{ $searchUtilities := $searchUtilities | minify | fingerprint "sha256" -}}
   {{ if eq .Title "Search"}}
-  {{ $fullSearch := $fullSearch | minify | fingerprint "md5" -}}
+  {{ $fullSearch := $fullSearch | minify | fingerprint "sha256" -}}
   {{ else }}
-  {{ $index := $index | minify | fingerprint "md5" -}}
+  {{ $index := $index | minify | fingerprint "sha256" -}}
   {{ end -}}
-  {{ $bs := $bs | minify | fingerprint "md5" -}}
-  {{ $highlight := $highlight | minify | fingerprint "md5" -}}
-  {{ $katex := $katex | minify | fingerprint "md5" -}}
-  {{ $katexAutoRender := $katexAutoRender | minify | fingerprint "md5" -}}
-  {{ $mermaid := $mermaid | minify | fingerprint "md5" -}}
+  {{ $bs := $bs | minify | fingerprint "sha256" -}}
+  {{ $highlight := $highlight | minify | fingerprint "sha256" -}}
+  {{ $katex := $katex | minify | fingerprint "sha256" -}}
+  {{ $katexAutoRender := $katexAutoRender | minify | fingerprint "sha256" -}}
+  {{ $mermaid := $mermaid | minify | fingerprint "sha256" -}}
   {{ if .Site.Params.options.bootStrapJs -}}
     <script src="{{ $bs.RelPermalink }}" integrity="{{ $bs.Data.Integrity }}" crossorigin="anonymous" defer></script>
   {{ end -}}

--- a/layouts/partials/head/stylesheet.html
+++ b/layouts/partials/head/stylesheet.html
@@ -5,7 +5,7 @@
 {{ else -}}
   {{ $options := (dict "targetPath" "main.css" "outputStyle" "compressed" "includePaths" (slice "node_modules")) -}}
   {{ $css := resources.Get "scss/app.scss" | toCSS $options | postCSS (dict "config" "config/postcss.config.js") -}}
-  {{ $secureCSS := $css | resources.Fingerprint "md5" -}}
+  {{ $secureCSS := $css | resources.Fingerprint "sha256" -}}
   <link rel="stylesheet" href="{{ $secureCSS.Permalink }}" integrity="{{ $secureCSS.Data.Integrity }}" crossorigin="anonymous">
 {{ end -}}
 <noscript><style>img.lazyload { display: none; }</style></noscript>


### PR DESCRIPTION
## Summary

Change integrity attribute to use sha256

## Basic example

![image](https://user-images.githubusercontent.com/19714551/235892428-7248bfa7-d140-4e79-b2ed-13b6e033993f.png)

## Motivation

md5 which was the previous value is not recommend by browsers and it emitted error.
