### PR TITLE
[Internal] Fixed documentation search

### DIFF
--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -11,6 +11,7 @@ baseUrl = baseUrl.endsWith('/') ? baseUrl : baseUrl + '/';
   let entries = [];
   let searchScheduled = false;
   search.addEventListener('input', show_results, true);
+  form.style.display = 'block';
 
   function showMoreResults(searchQuery) {
     if (searchQuery) window.localStorage.setItem('searchQuery', searchQuery);
@@ -37,7 +38,7 @@ baseUrl = baseUrl.endsWith('/') ? baseUrl : baseUrl + '/';
   }
 
   function show_results(limit) {
-    if (!this.value) {
+    if (!search.value) {
       searchScheduled = false;
       clearPrevResults();
       return;

--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -11,7 +11,7 @@ baseUrl = baseUrl.endsWith('/') ? baseUrl : baseUrl + '/';
   let entries = [];
   let searchScheduled = false;
   search.addEventListener('input', show_results, true);
-  form.style.display = 'block';
+  show_results();
 
   function showMoreResults(searchQuery) {
     if (searchQuery) window.localStorage.setItem('searchQuery', searchQuery);

--- a/layouts/partials/footer/script-footer.html
+++ b/layouts/partials/footer/script-footer.html
@@ -73,6 +73,15 @@
 </script>
 {{ $js := $slice | resources.Concat "main.js" -}}
 {{ if eq (hugo.Environment) "development" -}}
+  {{ if eq .Title "Search"}}
+    {{ if (.Site.Params.options.flexSearch) -}}
+    <script src="{{ $fullSearch.RelPermalink }}" defer></script>
+    {{ end -}}
+  {{ else }}
+    {{ if (.Site.Params.options.flexSearch) -}}
+    <script src="{{ $index.RelPermalink }}" defer></script>
+    {{ end -}}
+  {{ end -}}
   {{ if .Site.Params.options.bootStrapJs -}}
     <script src="{{ $bs.RelPermalink }}" defer></script>
   {{ end -}}
@@ -90,15 +99,6 @@
   {{ if (.Site.Params.options.flexSearch) -}}
     <script src="{{ $searchUtilities.RelPermalink }}" defer></script>
   {{ end -}}
-  {{ if eq .Title "Search"}}
-    {{ if (.Site.Params.options.flexSearch) -}}
-    <script src="{{ $fullSearch.RelPermalink }}" defer></script>
-    {{ end -}}
-  {{ else }}
-    {{ if (.Site.Params.options.flexSearch) -}}
-    <script src="{{ $index.RelPermalink }}" defer></script>
-    {{ end -}}
-  {{ end -}}
 {{ else -}}
   {{ $js := $js | minify | fingerprint "sha256" -}}
   {{ $searchUtilities := $searchUtilities | minify | fingerprint "sha256" -}}
@@ -112,6 +112,15 @@
   {{ $katex := $katex | minify | fingerprint "sha256" -}}
   {{ $katexAutoRender := $katexAutoRender | minify | fingerprint "sha256" -}}
   {{ $mermaid := $mermaid | minify | fingerprint "sha256" -}}
+  {{ if eq .Title "Search"}}
+    {{ if and (.Site.Params.options.flexSearch) -}}
+      <script src="{{ $fullSearch.Permalink }}" integrity="{{ $fullSearch.Data.Integrity }}" crossorigin="anonymous" defer></script>
+    {{ end -}}
+  {{ else }}
+    {{ if and (.Site.Params.options.flexSearch) -}}
+      <script src="{{ $index.Permalink }}" integrity="{{ $index.Data.Integrity }}" crossorigin="anonymous" defer></script>
+    {{ end -}}
+  {{ end -}}
   {{ if .Site.Params.options.bootStrapJs -}}
     <script src="{{ $bs.RelPermalink }}" integrity="{{ $bs.Data.Integrity }}" crossorigin="anonymous" defer></script>
   {{ end -}}
@@ -128,14 +137,5 @@
   {{ end -}}
   {{ if (.Site.Params.options.flexSearch) -}}
     <script src="{{ $searchUtilities.Permalink }}" integrity="{{ $searchUtilities.Data.Integrity }}" crossorigin="anonymous" defer></script>
-  {{ end -}}
-  {{ if eq .Title "Search"}}
-    {{ if and (.Site.Params.options.flexSearch) -}}
-      <script src="{{ $fullSearch.Permalink }}" integrity="{{ $fullSearch.Data.Integrity }}" crossorigin="anonymous" defer></script>
-    {{ end -}}
-  {{ else }}
-    {{ if and (.Site.Params.options.flexSearch) -}}
-      <script src="{{ $index.Permalink }}" integrity="{{ $index.Data.Integrity }}" crossorigin="anonymous" defer></script>
-    {{ end -}}
   {{ end -}}
 {{ end -}}

--- a/layouts/partials/header/header.html
+++ b/layouts/partials/header/header.html
@@ -127,7 +127,7 @@
     <div class="d-flex flex-row justify-content-between w-100">
       {{ if .Site.Params.options.flexSearch -}}
         <div class="doks-search d-inline-flex me-auto placeholder-glow">
-          <form id="form-search" class="doks-search position-relative me-md-auto d-flex">
+          <form id="form-search" style="display:none;" class="doks-search position-relative me-md-auto d-flex">
             <input id="search" class="form-control is-search me-2" type="search" placeholder="Search..."
               aria-label="Search..." autocomplete="off">
             <button id="start-search-btn" type="submit" style="background: none; border:none; width: 38px; height: 38px;">

--- a/layouts/partials/header/header.html
+++ b/layouts/partials/header/header.html
@@ -127,7 +127,7 @@
     <div class="d-flex flex-row justify-content-between w-100">
       {{ if .Site.Params.options.flexSearch -}}
         <div class="doks-search d-inline-flex me-auto placeholder-glow">
-          <form id="form-search" style="display:none;" class="doks-search position-relative me-md-auto d-flex">
+          <form id="form-search" class="doks-search position-relative me-md-auto d-flex">
             <input id="search" class="form-control is-search me-2" type="search" placeholder="Search..."
               aria-label="Search..." autocomplete="off">
             <button id="start-search-btn" type="submit" style="background: none; border:none; width: 38px; height: 38px;">


### PR DESCRIPTION
Documentation search is visible when it is fully loaded - index.js adds event listener to the search input and then displays it so the results or loading indicator are properly displayed. Also reordered the script files so the search is loaded before all the other scripts.

Task -> https://coherent-labs.atlassian.net/browse/COH-17550
Cohtml PR -> https://github.com/CoherentLabs/cohtml/pull/2212
UE4 PR -> https://github.com/CoherentLabs/CoherentUI_UE4/pull/534

Branch in the gameUIComponents that you can test the new changes where the doks theme ref is updated -> fix/documentation-search