### PR TITLE
Improved docs search regex to widen result scope

### DIFF
--- a/assets/js/fullSearch.js
+++ b/assets/js/fullSearch.js
@@ -162,7 +162,7 @@ var pagination = document.getElementById('pagination');
 
     clearPrevResults();
     window.localStorage.setItem('searchQuery', searchQuery);
-    const [resultIds, resultTitlesIds] = getIndexResults(searchQuery);
+    const [resultIds, resultTitlesIds] = getIndexResults(index, searchQuery);
 
     if (!hasResultsForQuery(resultIds, resultTitlesIds, searchQuery)) return;
 

--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -4,6 +4,11 @@ var suggestions = document.getElementById('suggestions');
 var search = document.getElementById('search');
 const form = document.getElementById('form-search');
 
+const MAX_LIMIT_PAGE_ENTRIES = 300; // https://github.com/nextapps-de/flexsearch#limit--offset
+const pagesCount = parseInt('{{.Site.Pages.Len}}');
+// This value has impact on the search performance.
+const searchDocumentsLimit = (pagesCount > MAX_LIMIT_PAGE_ENTRIES) ? MAX_LIMIT_PAGE_ENTRIES : pagesCount;
+
 let baseUrl = "{{.Site.BaseURL}}";
 
 baseUrl = baseUrl.endsWith('/') ? baseUrl : baseUrl + '/';
@@ -37,7 +42,7 @@ baseUrl = baseUrl.endsWith('/') ? baseUrl : baseUrl + '/';
     loader.classList.remove('d-none');
   }
 
-  function show_results(limit) {
+  function show_results() {
     if (!search.value) {
       searchScheduled = false;
       clearPrevResults();
@@ -55,23 +60,23 @@ baseUrl = baseUrl.endsWith('/') ? baseUrl : baseUrl + '/';
     search.removeEventListener('search-index-ready', show_results);
 
     clearPrevResults();
-    if (isNaN(limit)) limit = 3;
-    var searchQuery = this.value;
+    const searchQuery = this.value;
 
     form.addEventListener('submit', (event) => {
       event.preventDefault();
       showMoreResults(searchQuery);
     }, true)
 
-    const [resultIds, resultTitlesIds] = getIndexResults(searchQuery, limit);
+    const [resultIds, resultTitlesIds] = getIndexResults(index, searchQuery, searchDocumentsLimit);
 
     if (!hasResultsForQuery(resultIds, resultTitlesIds, searchQuery)) return;
 
     // construct a list of suggestions
-    constructTitleSuggestions(entries, resultTitlesIds, 'suggestion__description');
+    constructTitleSuggestions(entries, resultTitlesIds, 'suggestion__description', true);
 
+    const RESULTS_PER_DOCUMENT_LIMIT = 3;
     // construct a list of suggestions
-    constructContentSuggestions(entries, searchQuery, resultIds, 'suggestion__description', limit);
+    constructContentSuggestions(entries, searchQuery, resultIds, 'suggestion__description', true, RESULTS_PER_DOCUMENT_LIMIT);
 
     if (entries.length) {
       for (const entry of entries) {


### PR DESCRIPTION
* Minimized creation of live search suggestions (elements) improving performance
* Increased the FlexSearch index.search limit for more accuracy

Task: https://coherent-labs.atlassian.net/browse/COH-17546

## Notable changes:
* ### In (live) search, the title suggestions are now 5 and 3 are content suggestions e.g. searching for `image` will produce 5 suggestions related to the title (word may not exist in content) and 3 suggestions will be from the content of a document page (might not exist in title).
* ### Search suggestions (not full search) capped to 8 seemingly from 12. It seemed too long and has a little performance impact but it can be easily set back to 12. See the two screenshots below.
   * Before:
![image](https://github.com/CoherentLabs/cohtml/assets/21058220/69915241-54f9-466e-9b8a-5a9e98e410c5)
  * After:
![image](https://github.com/CoherentLabs/cohtml/assets/21058220/2d051336-c180-4dac-8a9d-5a47ea090df3)
------------------------
* ### Search now finds words individually, not as a whole phrase e.g. before `reduce footprint` had to be two words next to each other. See the two screenshots below.
  * Before:
![image](https://github.com/CoherentLabs/cohtml/assets/21058220/7b6635bc-63de-4479-956e-cd40c5cfdb40)
  * After: 
![image](https://github.com/CoherentLabs/cohtml/assets/21058220/b7de3067-71cc-45c0-af5a-256d428d3c70)
