### PR TITLE
Reintroduced table stripes targeting Components docs

### DIFF
--- a/assets/scss/components/_tables.scss
+++ b/assets/scss/components/_tables.scss
@@ -3,3 +3,11 @@ table {
 
   margin: 3rem 0;
 }
+
+.guic-docs-main table.table-dark tr:nth-child(even) > * {
+  background-color: #646464;
+}
+
+.guic-docs-main table.table tr:nth-child(even) > * {
+  background-color: rgba(238, 238, 238, 1.0);
+}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -11,9 +11,9 @@
 		</nav>
 		{{ end -}}
 		{{ if .Params.toc -}}
-		<main class="docs-content col-lg-11 col-xl-9">
+		<main class="docs-content col-lg-11 col-xl-9 {{ if (eq $.Site.Params.Title "Gameface Game UI Components") }}guic-docs-main{{ end }}">
 		{{ else -}}
-		<main class="docs-content col-lg-11 col-xl-9 mx-xl-auto">
+		<main class="docs-content col-lg-11 col-xl-9 mx-xl-auto {{ if (eq $.Site.Params.Title "Gameface Game UI Components") }}guic-docs-main{{ end }}">
 		{{ end -}}
 			<h1>{{ .Title }}</h1>
 			<p class="lead">{{ .Params.lead | safeHTML }}</p>


### PR DESCRIPTION
Before (when the global <table> styles were removed):
![image](https://github.com/CoherentLabs/doks/assets/21058220/f80da20e-c8fc-48a0-ad69-31d35c63fa30)

After:
![image](https://github.com/CoherentLabs/doks/assets/21058220/48d05bae-5784-47ce-aa60-4a9da0e0ff78)
