### PR TITLE
Enhanced docs tables and fixed toc

### DIFF
--- a/assets/scss/components/_tables.scss
+++ b/assets/scss/components/_tables.scss
@@ -4,10 +4,41 @@ table {
   margin: 3rem 0;
 }
 
-.guic-docs-main table.table-dark tr:nth-child(even) > * {
+.guic-docs-main table.table-dark tr:nth-child(even)>* {
   background-color: #646464;
 }
 
-.guic-docs-main table.table tr:nth-child(even) > * {
+.guic-docs-main table.table tr:nth-child(even)>* {
   background-color: rgba(238, 238, 238, 1.0);
+}
+
+@include media-breakpoint-down(sm) {
+  .sticky-table table thead {
+    top: 0px !important;
+  }
+}
+
+@include media-breakpoint-up(sm) {
+  .sticky-table table thead {
+    top: 56px !important;
+  }
+}
+
+.sticky-table table {
+  border-collapse: separate;
+  border-spacing: 0;
+}
+
+.sticky-table table thead tr th {
+  border-bottom: 2px solid currentColor !important;
+}
+
+.sticky-table table thead {
+  position: sticky;
+  background-color: var(--bs-body-bg);
+  top: 57px;
+}
+
+.sticky-table table tbody {
+  border-top: none !important;
 }

--- a/assets/scss/layouts/_header.scss
+++ b/assets/scss/layouts/_header.scss
@@ -96,7 +96,7 @@ button#doks-versions {
 }
 
 .doks-subnavbar {
-  background-color: rgba(255, 255, 255, 0.95);
+  background-color: rgba(255, 255, 255, 1);
   border-bottom: 1px solid $gray-200;
 }
 

--- a/assets/scss/layouts/_pages.scss
+++ b/assets/scss/layouts/_pages.scss
@@ -1,7 +1,7 @@
-.docs-content > h1[id]::before,
-.docs-content > h2[id]::before,
-.docs-content > h3[id]::before,
-.docs-content > h4[id]::before {
+.docs-content>h1[id]::before,
+.docs-content>h2[id]::before,
+.docs-content>h3[id]::before,
+.docs-content>h4[id]::before {
   display: block;
   height: 6rem;
   margin-top: -6rem;
@@ -36,6 +36,7 @@ h4:hover a {
 }
 
 @include media-breakpoint-up(md) {
+
   .edit-page,
   .last-modified {
     font-size: $font-size-base;

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -13,7 +13,7 @@
 		{{ if .Params.toc -}}
 		<main class="docs-content col-lg-11 col-xl-9">
 		{{ else -}}
-		<main class="docs-content col-lg-11 col-xl-9 mx-xl-auto">
+		<main class="docs-content col-lg-11 col-xl-9 flex-grow-1">
 		{{ end -}}
 			{{ if .Site.Params.options.breadCrumb -}}
 				<!-- https://discourse.gohugo.io/t/breadcrumb-navigation-for-highly-nested-content/27359/6 -->

--- a/layouts/shortcodes/table.html
+++ b/layouts/shortcodes/table.html
@@ -1,0 +1,9 @@
+{{ $stickyClass := "" }}
+{{ $sticky := .Get "sticky" }}
+{{ if and $sticky (eq $sticky "true") }}
+  {{ $stickyClass = "sticky-table" }}
+{{ end }}
+<div class="{{ $stickyClass }}">
+    {{- .Inner| markdownify -}}
+</div>
+  


### PR DESCRIPTION
Added new shortcode that can enable tables to have sticky headers. Make page to expand to all available width if the toc is disabled.

https://coherent-labs.atlassian.net/browse/COH-18498

You can check the running documentation here -> http://192.168.88.177:8080/
and the tables that are in the pages under content development -> supported features section