### PR TITLE
Fixed cookieconsent

### DIFF
--- a/assets/js/cookieconsent-init.js
+++ b/assets/js/cookieconsent-init.js
@@ -1,84 +1,94 @@
-const cc = initCookieConsent();
-
-// configuration
-cc.run({
-    current_lang: 'en',
-    autoclear_cookies: true,
-    page_scripts: true,
-    hide_from_bots: true,
-    // Even though _ga cookie has 2 years of expiration date
-    // (from the allowed 12 months according to GDPR/ePrivacy Directive),
-    // the consent form will show again and if declined, the GA related cookies will be deleted.
-    cookie_expiration: 356,
-    cookie_necessary_only_expiration: 356,
+const config = {
+    hideFromBots: true,
     // See https://github.com/orestbida/cookieconsent#how-to-enablemanage-revisions
     // Left for future reference if we change the consent.
     // revision: 0,
-
-    languages: {
-        'en': {
-            consent_modal: {
-                title: 'We use cookies!',
-                description: 'Hi, this website uses essential cookies to ensure its proper operation and tracking cookies to understand how you interact with it. The latter will be set only after consent. <button type="button" data-cc="c-settings" class="cc-link">Let me choose</button>',
-                primary_btn: {
-                    text: 'Accept all',
-                    role: 'accept_all',
-                },
-                secondary_btn: {
-                    text: 'Reject all',
-                    role: 'accept_necessary',
-                }
-            },
-            settings_modal: {
-                title: 'Cookie preferences',
-                save_settings_btn: 'Save settings',
-                accept_all_btn: 'Accept all',
-                reject_all_btn: 'Reject all',
-                close_btn_label: 'Close',
-                cookie_table_headers: [
-                    {col1: 'Name'},
-                    {col2: 'Domain'},
-                    {col3: 'Expiration'},
-                    {col4: 'Description'},
-                ],
-                blocks: [
+    cookie: {
+        name: "cc_cookie",
+        domain: location.hostname,
+        expiresAfterDays: 365,
+    },
+    categories: {
+        necessary: {
+            readOnly: true
+        },
+        analytics: {
+            autoClear: {
+                cookies: [
                     {
-                        title: 'Cookie usage 📢',
-                        description: `Cookies are used to ensure the basic functionalities of the website and to enhance your online experience. You can choose for each category to opt-in/out whenever you want. For more details relative to cookies and other sensitive data, please read the full <a href="${'{{ .Site.BaseURL }}{{ .Site.LanguagePrefix }}'}/privacy-policy/" class="cc-link" target="_blank">privacy policy</a>.`
-                    }, {
-                        title: 'Strictly necessary cookies',
-                        description: 'These cookies are essential for the proper functioning of my website. Without these cookies, the website may not work properly.',
-                        toggle: {
-                            value: 'necessary',
-                            enabled: true,
-                            readonly: true,
-                        }
-                    }, {
-                        title: 'Performance and Analytics cookies',
-                        description: 'These cookies allow the website to remember the choices you have made in the past.',
-                        toggle: {
-                            value: 'analytics',
-                            enabled: false,
-                            readonly: false,
+                        name: /^_ga/, // regex: match all cookies starting with '_ga'
+                    },
+                    {
+                        name: "_gid", // string: exact cookie name
+                    },
+                ],
+            },
+        },
+    },
+    language: {
+        default: "en",
+        translations: {
+            en: {
+                consentModal: {
+                    title: "We use cookies!",
+                    description:
+                        'Hi, this website uses essential cookies to ensure its proper operation and tracking cookies to understand how you interact with it. The latter will be set only after consent. <a data-cc="show-preferencesModal" class="cc-link">Let me choose</a>',
+                    acceptAllBtn: "Accept all",
+                    acceptNecessaryBtn: "Reject all",
+                    showPreferencesBtn: "Manage Individual preferences",
+                },
+                preferencesModal: {
+                    title: "Cookie preferences",
+                    acceptAllBtn: "Accept all",
+                    acceptNecessaryBtn: "Reject all",
+                    savePreferencesBtn: "Save settings",
+                    closeIconLabel: "Close",
+                    serviceCounterLabel: "Service|Services",
+                    sections: [
+                        {
+                            title: "Cookie usage 📢",
+                            description: `Cookies are used to ensure the basic functionalities of the website and to enhance your online experience. You can choose for each category to opt-in/out whenever you want. For more details relative to cookies and other sensitive data, please read the full <a href="/privacy-policy" class="cc-link" target="_blank">privacy policy</a>.`,
                         },
-                        cookie_table: [
-                            {
-                                col1: '^_ga',
-                                col2: 'google.com',
-                                col3: '2 years',
-                                col4: 'This cookie is a Google Analytics persistent cookie.',
-                                is_regex: true,
+                        {
+                            title: "Strictly necessary cookies",
+                            description:
+                                "These cookies are essential for the proper functioning of my website. Without these cookies, the website may not work properly.",
+                            linkedCategory: "necessary",
+                        },
+                        {
+                            title: "Performance and Analytics cookies",
+                            description:
+                                "These cookies allow the website to remember the choices you have made in the past.",
+                            linkedCategory: "analytics",
+                            cookieTable: {
+                                caption: "Cookie table",
+                                headers: {
+                                    name: "Cookie",
+                                    domain: "Domain",
+                                    desc: "Description",
+                                    duration: "Duration",
+                                },
+                                body: [
+                                    {
+                                        name: "_ga",
+                                        domain: 'google.com',
+                                        desc: "This cookie is a Google Analytics persistent cookie.",
+                                        duration: "2 years",
+                                    },
+                                    {
+                                        name: "_gid",
+                                        domain: 'google.com',
+                                        desc: "This cookie is a Google Analytics persistent cookie.",
+                                        duration: "1 day",
+                                    },
+                                ],
                             },
-                            {
-                                col1: '_gid',
-                                col2: 'google.com',
-                                col3: '1 day',
-                                col4: 'This cookie is a Google Analytics persistent cookie.',
-                            }
-                        ]
-                    }
-                ]
-            }
-        }
-    }
-});
+                        },
+                    ],
+                },
+            },
+        },
+    },
+};
+
+CookieConsent.run(config);

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -25,13 +25,21 @@
     {{ partial "footer/script-footer.html" . }}
 
     <!-- Google tag (gtag.js) -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id={{ .Site.Params.tagManagerId }}"></script>
-    <script>
+    <script 
+      type="text/plain"
+      data-category="analytics"
+      data-service="Google Analytics"
+      async src="https://www.googletagmanager.com/gtag/js?id={{ .Site.Params.tagManagerId }}"></script>
+    <script 
+      type="text/plain"
+      data-category="analytics"
+      data-service="Google Analytics"
+    >
       window.dataLayer = window.dataLayer || [];
       function gtag(){dataLayer.push(arguments);}
       gtag('js', new Date());
 
-      gtag('config', {{ .Site.Params.tagManagerId }});
+      gtag('config', '{{ .Site.Params.tagManagerId }}');
     </script>
 
     {{ partial "content/google-analytics-events.html" . }}

--- a/layouts/partials/footer/script-footer.html
+++ b/layouts/partials/footer/script-footer.html
@@ -61,10 +61,10 @@
   {{ $slice = $slice | append $katexConfig -}}
 {{ end -}}
 
+{{ $cookieConsentPlugin := resources.Get "vanilla-cookieconsent/cookieconsent.umd.js" -}}
 {{ if .Site.Params.options.cookieConsent }}
-  {{ $cookieConsentPlugin := resources.Get "vanilla-cookieconsent/cookieconsent.js" -}}
   {{ $cookieConsentInit := resources.Get "js/cookieconsent-init.js" | resources.ExecuteAsTemplate "js/cookieconsent-init.js" . | minify | fingerprint "sha256" -}}
-  {{ $slice = $slice | append $cookieConsentPlugin | append $cookieConsentInit -}}
+  {{ $slice = $slice | append $cookieConsentInit -}}
 {{ end -}}
 
 <script>
@@ -75,6 +75,9 @@
 </script>
 {{ $js := $slice | resources.Concat "main.js" -}}
 {{ if eq (hugo.Environment) "development" -}}
+  {{ if (.Site.Params.options.cookieConsent) -}}
+  <script src="{{ $cookieConsentPlugin.RelPermalink }}" defer></script>
+  {{ end -}}
   {{ if eq .Title "Search"}}
     {{ if (.Site.Params.options.flexSearch) -}}
     <script src="{{ $fullSearch.RelPermalink }}" defer></script>
@@ -103,6 +106,9 @@
   {{ end -}}
 {{ else -}}
   {{ $js := $js | minify | fingerprint "sha256" -}}
+  {{ if (.Site.Params.options.cookieConsent) -}}
+    <script src="{{ $cookieConsentPlugin.RelPermalink }}" integrity="{{ $cookieConsentPlugin.Data.Integrity }}" crossorigin="anonymous" defer></script>
+  {{ end -}}
   {{ $searchUtilities := $searchUtilities | minify | fingerprint "sha256" -}}
   {{ if eq .Title "Search"}}
   {{ $fullSearch := $fullSearch | minify | fingerprint "sha256" -}}


### PR DESCRIPTION
Updated cookie consent config to v.3+ structure. Fixed minifying new version in production. Fixed gtag cookie not removed if you reject the consent.

To test -> 
1. Open cohtml documentation source folder. 
2. Change "vanilla-cookieconsent" dependency from "^2.8.0" to "^3.0.1" and install. 
3. Change the ref to the doks theme to this pr in the Documentation_Source/themes/doks. 
4. Build the documentation and check if the consent works properly by:
    * Accepting the consent -> check Inspector -> application -> cookies if there is _ga or similar cookie enabled.
    * Rejecting the consent -> the gtag cookie should not be added.